### PR TITLE
prioritizing the relationships over boolean operators #42

### DIFF
--- a/Private/parser.py
+++ b/Private/parser.py
@@ -87,14 +87,16 @@ def enumerated_list():          return "[", ZeroOrMore(expression, ","), express
 def private_list():             return [list_comprehension, enumerated_list]
 def bracketed_expression():     return "(", expression, ")"
 def factor():                   return [function_call, method_call, indexed_variable, bracketed_expression, (notsym, factor), private_list, atom], Optional(leftsquarebrack, expression, colon, expression, rightsquarebrack)
-def term():                     return factor, ZeroOrMore(["*","/", "or"], factor)
-def simple_expression():        return Optional(["+", "-"]), term, ZeroOrMore(["+", "-", "and"], term)
+def term():                     return factor, ZeroOrMore(["*","/"], factor)
+def simple_expression():        return Optional(["+", "-"]), term, ZeroOrMore(["+", "-"], term)
+def comparison():               return simple_expression, ZeroOrMore(relation, simple_expression)
+def boolean_expression():       return comparison, ZeroOrMore(["and","or"], comparison)
 def named_argument():           return identifier, "=", expression
 def argument():                 return [named_argument, expression]
 def function_call():            return identifier, "(", ZeroOrMore(argument, ","), argument, ")"
 def method_call():              return dottedidentifier, "(", ZeroOrMore(expression, ","), expression, ")"
 def indexed_variable():         return dottedidentifier, "[", ZeroOrMore(expression, ","), expression, "]"
-def expression():               return simple_expression, Optional(relation, simple_expression)
+def expression():               return [boolean_expression, simple_expression]
 def deterministic_assignment(): return identifier, "=", expression
 def distribution_name():        return ["Normal", "HalfNormal", "Uniform", "SkewNormal", "Beta", "Kumaraswamy", "Exponential", "Laplace", "StudentT", "halfStudentT", "Cauchy", "HalfCauchy", "Gamma", "Weibull", "Lognormal", "ChiSquared", "Wald", "Pareto", "InverseGamma", "Exgaussian", "VonMises", "Triangular", "Gumbel", "Logistic", "LogitNormal", "Binomial", "ZeroInflatedBinomial", "Bernoulli", "Poisson", "ZeroInflatedPoisson", "NegativeBinomial", "ZeroInflatedNegativeBinomial", "DiscreteUniform", "Geometric", "Categorical", "DiscreteWeibull", "Constant", "OrderedLogistic"]
 def distribution_parameter():   return [number, (identifier, Optional("[", identifier, "]"))]

--- a/Private/semantics.py
+++ b/Private/semantics.py
@@ -117,6 +117,22 @@ class InputVisitor(PTNodeVisitor):
             evalcode = " ".join(c if type(c) == unicode else c.evalcode for c in children)
             return result("factor", code, children, evalcode=evalcode)
 
+    def visit_comparison(self, node, children):
+        if len(children) == 1:
+            return result("comparison", children[0].code, children, evalcode = children[0].evalcode)
+        else:
+            code = " ".join(c if type(c) == unicode else c.code for c in children)
+            evalcode = " ".join(c if type(c) == unicode else c.evalcode for c in children)
+            return result("comparison", code, children, evalcode=evalcode)
+
+    def visit_boolean_expression(self, node, children):
+        if len(children) == 1:
+            return result("boolean_expression", children[0].code, children, evalcode = children[0].evalcode)
+        else:
+            code = " ".join(c if type(c) == unicode else c.code for c in children)
+            evalcode = " ".join(c if type(c) == unicode else c.evalcode for c in children)
+            return result("boolean_expression", code, children, evalcode=evalcode)
+
     def visit_term(self, node, children):
         if len(children) == 1:
             return result("term", children[0].code, children, evalcode = children[0].evalcode)


### PR DESCRIPTION
Target of the change was to get following precedence order 

1. *, /
2. +, -
3. comparisons (==, !=, <, >, <=, >=)
4. Boolean AND, Boolean OR

Earlier this was in following order

1. *, /, Boolean OR
2. +, -, Boolean AND
3. comparisons (==, !=, <, >, <=, >=)
